### PR TITLE
fix: add check for component variant node type

### DIFF
--- a/packages/components/src/FigspecViewer/ViewerMixin.ts
+++ b/packages/components/src/FigspecViewer/ViewerMixin.ts
@@ -332,11 +332,13 @@ export const ViewerMixin = <T extends Constructor<LitElement>>(
         !(
           node.type === "CANVAS" ||
           node.type === "FRAME" ||
-          node.type === "COMPONENT"
+          node.type === "COMPONENT" ||
+          //@ts-ignore TODO: update types once there are updates in https://github.com/jongold/figma-js
+          node.type === "COMPONENT_SET"
         )
       ) {
         throw new Error(
-          "Cannot update node tree: Top level node MUST be one of CANVAS, FRAME, or COMPONENT"
+          "Cannot update node tree: Top level node MUST be one of CANVAS, FRAME, COMPONENT, or COMPONENT_SET"
         );
       }
 


### PR DESCRIPTION
Issue: #22

Before:

![image](https://user-images.githubusercontent.com/1671563/118345230-5f31f080-b533-11eb-9bc9-4d5077852c59.png)

After:

![image](https://user-images.githubusercontent.com/1671563/118345200-3dd10480-b533-11eb-9851-2195b86a8604.png)


I believe there are pretty interesting stuff we can do with the payload from a component variant, but just adding support for it to render is already a good start