### PR TITLE
Feat(@figspec/react): add link prop

### DIFF
--- a/packages/react/src/index.stories.jsx
+++ b/packages/react/src/index.stories.jsx
@@ -29,3 +29,10 @@ demo.args = {
   nodes: demoJson,
   renderedImage: demoImage,
 };
+
+export const withLink = Template.bind({});
+
+withLink.args = {
+  ...demo.args,
+  link: "https://figma.com",
+};

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -49,6 +49,7 @@ type FigspecFrameViewerElementProps =
         | "zoomSpeed"
         | "panSpeed"
         | "zoomMargin"
+        | "link"
       >
     >;
 
@@ -161,6 +162,7 @@ type FigspecFileViewerElementProps =
         | "zoomSpeed"
         | "panSpeed"
         | "zoomMargin"
+        | "link"
       >
     >;
 


### PR DESCRIPTION
Now that @figspec/components have a link property, it should be also possible to pass it via the react wrapper