### PR TITLE
fix: apply correct zindex and border to footer and sidebar

### DIFF
--- a/packages/components/src/FigspecViewer/Footer/Footer.ts
+++ b/packages/components/src/FigspecViewer/Footer/Footer.ts
@@ -6,6 +6,8 @@ import { fromNow } from "./utils";
 export const styles = css`
   .figma-footer {
     flex: 0;
+    z-index: calc(var(--z-index) + 1);
+    border-top: 1px solid #ccc;
     min-height: 48px;
     padding: 0 16px;
     text-decoration: none;

--- a/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
+++ b/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
@@ -139,6 +139,7 @@ export const styles = css`
     background: white;
     border-left: 1px solid #ccc;
     overflow-y: auto;
+    z-index: calc(var(--z-index) + 2);
   }
 
   .inspector-view h4 {


### PR DESCRIPTION
The footer should be above the design, but below the sidebar. When developing I didn't check figspec in a smaller frame so I didn't notice. Silly mistake, my bad!

Before:
![image](https://user-images.githubusercontent.com/1671563/118376235-fbf19e00-b5c6-11eb-9322-4da0e399dbe5.png)

After:
![image](https://user-images.githubusercontent.com/1671563/118376238-feec8e80-b5c6-11eb-8dcc-fe12e64b4851.png)
