### PR TITLE
remove copy-to-clipboard

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,7 +26,6 @@
     "./{cjs,esm}/*/index.js"
   ],
   "dependencies": {
-    "copy-to-clipboard": "^3.0.0",
     "lit": "^2.1.3"
   },
   "devDependencies": {

--- a/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
+++ b/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
@@ -14,7 +14,7 @@ const copy = async (text: string) => {
   let status = { state: "granted" };
   try {
     status = await navigator.permissions.query({
-      name: "clipboard-write" as unknown as PermissionName,
+      name: ("clipboard-write" as unknown) as PermissionName,
     });
   } catch (e) {
     // Firefox throws because it doesn't support clipboard-write allowed

--- a/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
+++ b/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
@@ -10,21 +10,7 @@ import { FigmaNode, getStyleRule, NodeStyles } from "./utils";
 import type { CSSRule } from "./utils";
 
 const copy = async (text: string) => {
-  // workaround for Firefox & Safari which do not need clipboard-write permission
-  let status = { state: "granted" };
-  try {
-    status = await navigator.permissions.query({
-      name: ("clipboard-write" as unknown) as PermissionName,
-    });
-  } catch (e) {
-    // Firefox throws because it doesn't support clipboard-write allowed
-    // by default in secure environments. Safari throws because it does not have
-    // or need navigator.permissions.
-  }
-
-  if (status.state === "granted") {
-    await navigator.clipboard.writeText(text);
-  }
+  await navigator.clipboard.writeText(text);
 };
 
 export type InspectorViewProps = {

--- a/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
+++ b/packages/components/src/FigspecViewer/InspectorView/InspectorView.ts
@@ -1,5 +1,4 @@
 import { css, html } from "lit";
-import * as copy from "copy-to-clipboard";
 
 import {
   HorizontalPaddingIcon,
@@ -9,6 +8,24 @@ import {
 } from "../Icons";
 import { FigmaNode, getStyleRule, NodeStyles } from "./utils";
 import type { CSSRule } from "./utils";
+
+const copy = async (text: string) => {
+  // workaround for Firefox & Safari which do not need clipboard-write permission
+  let status = { state: "granted" };
+  try {
+    status = await navigator.permissions.query({
+      name: "clipboard-write" as unknown as PermissionName,
+    });
+  } catch (e) {
+    // Firefox throws because it doesn't support clipboard-write allowed
+    // by default in secure environments. Safari throws because it does not have
+    // or need navigator.permissions.
+  }
+
+  if (status.state === "granted") {
+    await navigator.clipboard.writeText(text);
+  }
+};
 
 export type InspectorViewProps = {
   node: FigmaNode;

--- a/packages/components/src/FigspecViewer/InspectorView/utils.ts
+++ b/packages/components/src/FigspecViewer/InspectorView/utils.ts
@@ -191,7 +191,7 @@ export class NodeStyles {
         this.color = extractColorStyle(fillColor.color);
       } else if (fillColor.type.includes("GRADIENT")) {
         this.backgroundImage = extractGradientColorStyle(
-          fillColor as unknown as ElementGradientColor
+          (fillColor as unknown) as ElementGradientColor
         );
       } else if (fillColor.type === "SOLID") {
         this.background = extractColorStyle(fillColor.color);

--- a/packages/components/src/FigspecViewer/ViewerMixin.ts
+++ b/packages/components/src/FigspecViewer/ViewerMixin.ts
@@ -397,8 +397,10 @@ export const ViewerMixin = <T extends Constructor<LitElement>>(
       if (this.#canvasSize) {
         // Set initial zoom level based on element size
         const { width, height } = this.#canvasSize;
-        const { width: elementWidth, height: elementHeight } =
-          this.getBoundingClientRect();
+        const {
+          width: elementWidth,
+          height: elementHeight,
+        } = this.getBoundingClientRect();
 
         const wDiff = elementWidth / (width + this.zoomMargin * 2);
         const hDiff = elementHeight / (height + this.zoomMargin * 2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4463,7 +4463,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-to-clipboard@^3.0.0, copy-to-clipboard@^3.3.1:
+copy-to-clipboard@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
   integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==


### PR DESCRIPTION
## Background

I was trying to import this using a CDN and native ES Modules, but then I ran into the issue that this package's ESM build uses `copy-to-clipboard` which is written in CJS. This means when you try to load this package, it throws an error in `copy-to-clipboard` that `require` is not defined.

## Changes

I've replaced `copy-to-clipboard` with the native clipboard api. Browser compatibility can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText#browser_compatibility).

This _should_ allow using this package with just:

`import "https://unpkg.com/@figspec/components?module"`

## Testing

I was able to test this manually in Chrome and Firefox with the `storybook` command.

Safari did not allow me to click on anything and bring up the inspector view. Not sure why. But, i ran the `copy` function separately in another window and it copied correctly.