### PR TITLE
feat: add zoom controls to figspec viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "figma",
     "webcomponents"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "contributors": [
     {
       "name": "Shota Fuji",

--- a/src/FigspecViewer/FigspecFileViewer.stories.js
+++ b/src/FigspecViewer/FigspecFileViewer.stories.js
@@ -35,6 +35,8 @@ const Template = (args) => html`
     .zoomSpeed=${args.zoomSpeed || 500}
     zoom-margin=${args.zoomMargin || 50}
     link=${args.link || "https://figma.com"}
+    .showZoomControls=${args.showZoomControls || false}
+    .scalePercentage=${args.scalePercentage || 25}
   ></figspec-file-viewer>
 `;
 
@@ -49,4 +51,18 @@ Defaults.args = {
     "93:14": image93_14,
     "93:32": image93_32,
   },
+};
+
+export const WithZoomControls = Template.bind({});
+WithZoomControls.args = {
+  documentNode: demoJson,
+  renderedImages: {
+    "2:5": image2_5,
+    "2:9": image2_9,
+    "2:13": image2_13,
+    "64:1": image64_1,
+    "93:14": image93_14,
+    "93:32": image93_32,
+  },
+  showZoomControls: true,
 };

--- a/src/FigspecViewer/FigspecFileViewer.ts
+++ b/src/FigspecViewer/FigspecFileViewer.ts
@@ -47,6 +47,16 @@ import { extendStyles } from "./utils";
  * setting a default zooming scale for the canvas.
  * @attr [zoom-margin=50] See docs for `zoomMargin` property.
  *
+ * @property {number} [scalePercentage=25]
+ * The scale percentage to use when using zoom controls.
+ * Available values: 1 ~ 100
+ * @attr [scale-percentage=25] See docs for `scalePercentage` property.
+ *
+ * @property {boolean} [showZoomControls=false]
+ * Whether to show the zoom controls buttons.
+ * Available values: true / false
+ * @attr [show-zoom-controls=false] See docs for `showZoomControls` property.
+ *
  * @fires scalechange When a user zoom-in or zoom-out the preview.
  * @fires positionchange When a user panned the preview.
  * @fires nodeselect When a user selected / unselected a node.

--- a/src/FigspecViewer/FigspecFrameViewer.stories.js
+++ b/src/FigspecViewer/FigspecFrameViewer.stories.js
@@ -30,6 +30,8 @@ const Template = (args) => html`
     .panSpeed=${args.panSpeed || 500}
     .zoomSpeed=${args.zoomSpeed || 500}
     zoom-margin=${args.zoomMargin || 50}
+    .showZoomControls=${args.showZoomControls || false}
+    .scalePercentage=${args.scalePercentage || 25}
   ></figspec-frame-viewer>
 `;
 
@@ -52,6 +54,16 @@ Slow.args = {
   zoomSpeed: 100,
 };
 
+export const WithZoomControls = Template.bind({});
+
+WithZoomControls.storyName = "With Zoom Controls";
+
+WithZoomControls.args = {
+  nodes: demoJson,
+  renderedImage: demoImage,
+  showZoomControls: true,
+};
+
 export const WithoutRequiredValues = Template.bind({});
 
 WithoutRequiredValues.args = {};
@@ -68,6 +80,8 @@ export const Events = (args) => html`
     .panSpeed=${args.panSpeed || 500}
     .zoomSpeed=${args.zoomSpeed || 500}
     zoom-margin=${args.zoomMargin || 50}
+    .showZoomControls=${args.showZoomControls || false}
+    .scalePercentage=${args.scalePercentage || 25}
     @scalechange=${action("scalechange")}
     @positionchange=${action("positionchange")}
     @nodeselect=${action("nodeselect")}

--- a/src/FigspecViewer/FigspecFrameViewer.ts
+++ b/src/FigspecViewer/FigspecFrameViewer.ts
@@ -47,6 +47,16 @@ import { SizedNode } from "./utils";
  * setting a default zooming scale for the canvas.
  * @attr [zoom-margin=50] See docs for `zoomMargin` property.
  *
+ * @property {number} [scalePercentage=25]
+ * The scale percentage to use when using zoom controls.
+ * Available values: 1 ~ 100
+ * @attr [scale-percentage=25] See docs for `scalePercentage` property.
+ *
+ * @property {boolean} [showZoomControls=false]
+ * Whether to show the zoom controls buttons.
+ * Available values: true / false
+ * @attr [show-zoom-controls=false] See docs for `showZoomControls` property.
+ *
  * @fires scalechange When a user zoom-in or zoom-out the preview.
  * @fires positionchange When a user panned the preview.
  * @fires nodeselect When a user selected / unselected a node.

--- a/src/FigspecViewer/ViewerMixin.ts
+++ b/src/FigspecViewer/ViewerMixin.ts
@@ -40,8 +40,10 @@ export interface IViewer {
   __updateTree(node: Figma.Node): void;
   __updateEffectMargins(): void;
   resetZoom(): void;
+  resetZoomAndPan(): void;
   zoomIn(): void;
   zoomOut(): void;
+  panMode(e: MouseEvent): void;
   getMetadata():
     | { fileName: string; timestamp: Date | string; link: string }
     | undefined;


### PR DESCRIPTION
Add zoom and move controls for Figspec Viewer. 
Hidden by default.

@pocka Would like to get your thoughts on this and if can be merged?

https://user-images.githubusercontent.com/16789433/178019020-f9140380-ff89-452a-b97e-713a435bea3f.mov

