### PR TITLE
chore: add repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "email": "pockawoooh@gmail.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pocka/figspec.git"
+  },
   "license": "MIT",
   "main": "esm/es2019/index.js",
   "type": "module",


### PR DESCRIPTION
The updated "repository" field in `package.json` enables easy access to the package's source code and assists automated tools in locating the repository.