### PR TITLE
add alt text to the rendered image

### DIFF
--- a/src/FrameCanvas/FrameCanvas.ts
+++ b/src/FrameCanvas/FrameCanvas.ts
@@ -214,6 +214,7 @@ export class FrameCanvas {
 
           const img = el("img", [
             attr("src", renderedImage),
+            attr("alt", `Figma frame: ${node.name}`),
             className("fc-rendered-image"),
             style({
               left: box.x + "px",


### PR DESCRIPTION
This is a small accessibility fix, adding alt text to the image rendered for a figma frame, `Figma frame: ${node.name}`.