### PR TITLE
Hide checkmark from AT for choice component

### DIFF
--- a/src/ui/preferencesPanel/choice.ts
+++ b/src/ui/preferencesPanel/choice.ts
@@ -136,7 +136,7 @@ export function choice<T extends string>({
           }),
         ],
         [
-          check([className("pp-choice-check")]),
+          check([className("pp-choice-check"), attr("aria-hidden", "true")]),
           el("label", [attr("for", id), className("pp-choice-label")], [label]),
           description &&
             el(


### PR DESCRIPTION
~This adjusts the choice's checkmark to use an `aria-label` when the choice is selected and `aria-hidden` when the choice is not. This improves the distinction between the selected and non-selected choice if read by a screenreader (outside of focus on the underlying input).~

This now just always hides the checkmark since it is purely presentational

This is per this comment: https://github.com/pocka/figspec/pull/54#issuecomment-3576553907

