### PR TITLE
Add `theme` attribute to allow the color scheme to be set by consumer

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -188,16 +188,16 @@ const darkStyles = /* css */ `
 `;
 
 const colorSchemeStyles = /* css */ `
-  :host([color-scheme="light"]) {
+  :host([theme="light"]) {
     color-scheme: light;
   }
 
-  :host([color-scheme="dark"]) {
+  :host([theme="dark"]) {
     ${darkStyles}
   }
 
-  :host(:not([color-scheme="light"])) {
-    @media (prefers-color-scheme: dark) {
+  @media (prefers-color-scheme: dark) {
+    :host(:not([theme="light"])) {
       ${darkStyles}
     }
   }

--- a/website/index.html
+++ b/website/index.html
@@ -140,11 +140,11 @@
             </tr>
             <tr>
               <td>
-                <code>color-scheme</code>
+                <code>theme</code>
               </td>
               <td>
-                Optional. The color scheme to use, either "light" or "dark". If
-                not specified the user's preferred color scheme is used.
+                Optional. The theme to use, either "light" or "dark". If not
+                specified the user's preferred color scheme is used.
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
This changes the css to allow the consumer to set a `theme` property on either `figspec-frame-viewer` or `figspec-file-viewer` element to set the color scheme to be used.

When no `theme` property exists the user's preference will be respected, which is the current behavior.

Additionally, this sets `color-scheme: dark` on `:host` when the dark theme is used to allow links to use the appropriate colors. Similarly if the light theme is explicitly set via the color-scheme attribute, then `color-scheme: light` will be set.