### PR TITLE
Add keyboard support for pan and zoom actions

### DIFF
--- a/src/FrameCanvas/FrameCanvas.ts
+++ b/src/FrameCanvas/FrameCanvas.ts
@@ -1,12 +1,6 @@
 import { attr, className, el, on, style, svg } from "../dom.js";
 import * as figma from "../figma.js";
-import {
-  roundTo,
-  nextPowerOfTwo,
-  previousPowerOfTwo,
-  MAX_SCALE,
-  MIN_SCALE,
-} from "../math.js";
+import { roundTo, nextPowerOfTwo, previousPowerOfTwo } from "../math.js";
 import { type Preferences } from "../preferences.js";
 import { effect, Signal } from "../signal.js";
 
@@ -30,6 +24,9 @@ const enum TouchingStateModes {
   Panning = 0,
   Scaling,
 }
+
+const MIN_SCALE = 2 ** -6;
+const MAX_SCALE = 2 ** 8;
 
 interface Panning {
   mode: TouchingStateModes.Panning;
@@ -812,8 +809,8 @@ export class FrameCanvas {
     if (ev.key === "=" || ev.key === "-") {
       this.#scale =
         ev.key === "="
-          ? nextPowerOfTwo(this.#scale)
-          : previousPowerOfTwo(this.#scale);
+          ? nextPowerOfTwo(this.#scale, { min: MIN_SCALE, max: MAX_SCALE })
+          : previousPowerOfTwo(this.#scale, { min: MIN_SCALE, max: MAX_SCALE });
     } else {
       // Figma moves ~65px per keydown, 13 percent of the default viewport pan speed of 500 is 65px;
       const distance = this.#preferences.viewportPanSpeed * 0.13;

--- a/src/math.spec.ts
+++ b/src/math.spec.ts
@@ -1,11 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  roundTo,
-  nextPowerOfTwo,
-  previousPowerOfTwo,
-  MAX_SCALE,
-  MIN_SCALE,
-} from "./math";
+import { roundTo, nextPowerOfTwo, previousPowerOfTwo } from "./math";
 
 describe("roundTo", () => {
   it("Should round to int without `at` parameter", () => {
@@ -19,114 +13,71 @@ describe("roundTo", () => {
   });
 });
 
+const options = {
+  min: 2 ** -3,
+  max: 2 ** 3,
+};
+
 describe("nextPowerOfTwo", () => {
   it("Should return the next power of two, clamped within min and max zoom", () => {
-    expect(nextPowerOfTwo(MIN_SCALE)).toBe(2 ** -5);
-    expect(nextPowerOfTwo(2 ** -5.1)).toBe(2 ** -5);
+    expect(nextPowerOfTwo(options.min, options)).toBe(2 ** -2);
+    expect(nextPowerOfTwo(2 ** -2.5, options)).toBe(2 ** -2);
 
-    expect(nextPowerOfTwo(2 ** -5)).toBe(2 ** -4);
-    expect(nextPowerOfTwo(2 ** -4.1)).toBe(2 ** -4);
+    expect(nextPowerOfTwo(2 ** -2, options)).toBe(2 ** -1);
+    expect(nextPowerOfTwo(2 ** -1.5, options)).toBe(2 ** -1);
 
-    expect(nextPowerOfTwo(2 ** -4)).toBe(2 ** -3);
-    expect(nextPowerOfTwo(2 ** -3.1)).toBe(2 ** -3);
+    expect(nextPowerOfTwo(2 ** -1, options)).toBe(1);
+    expect(nextPowerOfTwo(2 ** -0.5, options)).toBe(1);
 
-    expect(nextPowerOfTwo(2 ** -3)).toBe(2 ** -2);
-    expect(nextPowerOfTwo(2 ** -2.1)).toBe(2 ** -2);
+    expect(nextPowerOfTwo(1, options)).toBe(2);
+    expect(nextPowerOfTwo(1.5, options)).toBe(2);
 
-    expect(nextPowerOfTwo(2 ** -2)).toBe(2 ** -1);
-    expect(nextPowerOfTwo(2 ** -1.1)).toBe(2 ** -1);
+    expect(nextPowerOfTwo(2, options)).toBe(4);
+    expect(nextPowerOfTwo(3, options)).toBe(4);
 
-    expect(nextPowerOfTwo(2 ** -1)).toBe(1);
-    expect(nextPowerOfTwo(2 ** -0.1)).toBe(1);
+    expect(nextPowerOfTwo(4, options)).toBe(8);
+    expect(nextPowerOfTwo(5, options)).toBe(8);
 
-    expect(nextPowerOfTwo(1)).toBe(2);
-    expect(nextPowerOfTwo(1.1)).toBe(2);
-
-    expect(nextPowerOfTwo(2)).toBe(4);
-    expect(nextPowerOfTwo(3)).toBe(4);
-
-    expect(nextPowerOfTwo(4)).toBe(8);
-    expect(nextPowerOfTwo(5)).toBe(8);
-
-    expect(nextPowerOfTwo(8)).toBe(16);
-    expect(nextPowerOfTwo(9)).toBe(16);
-
-    expect(nextPowerOfTwo(16)).toBe(32);
-    expect(nextPowerOfTwo(17)).toBe(32);
-
-    expect(nextPowerOfTwo(32)).toBe(64);
-    expect(nextPowerOfTwo(33)).toBe(64);
-
-    expect(nextPowerOfTwo(64)).toBe(128);
-    expect(nextPowerOfTwo(65)).toBe(128);
-
-    expect(nextPowerOfTwo(128)).toBe(256);
-    expect(nextPowerOfTwo(129)).toBe(256);
-
-    expect(nextPowerOfTwo(MAX_SCALE)).toBe(MAX_SCALE);
+    expect(nextPowerOfTwo(options.max, options)).toBe(options.max);
   });
 
   it("Should return max zoom if input is greater than max zoom", () => {
-    expect(nextPowerOfTwo(MAX_SCALE + 1)).toBe(MAX_SCALE);
+    expect(nextPowerOfTwo(options.max + 1, options)).toBe(options.max);
   });
 
   it("Should return min zoom if input is less than min zoom", () => {
-    expect(nextPowerOfTwo(MIN_SCALE - 1)).toBe(MIN_SCALE);
+    expect(nextPowerOfTwo(options.min - 1, options)).toBe(options.min);
   });
 });
 
 describe("previousPowerOfTwo", () => {
   it("Should return the previous power of two, clamped within min and max zoom", () => {
-    expect(previousPowerOfTwo(MAX_SCALE)).toBe(128);
-    expect(previousPowerOfTwo(255)).toBe(128);
+    expect(previousPowerOfTwo(options.max, options)).toBe(4);
+    expect(previousPowerOfTwo(7, options)).toBe(4);
 
-    expect(previousPowerOfTwo(128)).toBe(64);
-    expect(previousPowerOfTwo(127)).toBe(64);
+    expect(previousPowerOfTwo(4, options)).toBe(2);
+    expect(previousPowerOfTwo(3, options)).toBe(2);
 
-    expect(previousPowerOfTwo(64)).toBe(32);
-    expect(previousPowerOfTwo(63)).toBe(32);
+    expect(previousPowerOfTwo(2, options)).toBe(1);
+    expect(previousPowerOfTwo(1.5, options)).toBe(1);
 
-    expect(previousPowerOfTwo(32)).toBe(16);
-    expect(previousPowerOfTwo(31)).toBe(16);
+    expect(previousPowerOfTwo(1, options)).toBe(2 ** -1);
+    expect(previousPowerOfTwo(2 ** -0.5, options)).toBe(2 ** -1);
 
-    expect(previousPowerOfTwo(16)).toBe(8);
-    expect(previousPowerOfTwo(15)).toBe(8);
+    expect(previousPowerOfTwo(2 ** -1, options)).toBe(2 ** -2);
+    expect(previousPowerOfTwo(2 ** -1.5, options)).toBe(2 ** -2);
 
-    expect(previousPowerOfTwo(8)).toBe(4);
-    expect(previousPowerOfTwo(7)).toBe(4);
+    expect(previousPowerOfTwo(2 ** -2, options)).toBe(2 ** -3);
+    expect(previousPowerOfTwo(2 ** -2.5, options)).toBe(2 ** -3);
 
-    expect(previousPowerOfTwo(4)).toBe(2);
-    expect(previousPowerOfTwo(3)).toBe(2);
-
-    expect(previousPowerOfTwo(2)).toBe(1);
-    expect(previousPowerOfTwo(1.9)).toBe(1);
-
-    expect(previousPowerOfTwo(1)).toBe(2 ** -1);
-    expect(previousPowerOfTwo(0.9)).toBe(2 ** -1);
-
-    expect(previousPowerOfTwo(2 ** -1)).toBe(2 ** -2);
-    expect(previousPowerOfTwo(2 ** -1.1)).toBe(2 ** -2);
-
-    expect(previousPowerOfTwo(2 ** -2)).toBe(2 ** -3);
-    expect(previousPowerOfTwo(2 ** -2.1)).toBe(2 ** -3);
-
-    expect(previousPowerOfTwo(2 ** -3)).toBe(2 ** -4);
-    expect(previousPowerOfTwo(2 ** -3.1)).toBe(2 ** -4);
-
-    expect(previousPowerOfTwo(2 ** -4)).toBe(2 ** -5);
-    expect(previousPowerOfTwo(2 ** -4.1)).toBe(2 ** -5);
-
-    expect(previousPowerOfTwo(2 ** -5)).toBe(2 ** -6);
-    expect(previousPowerOfTwo(2 ** -5.1)).toBe(2 ** -6);
-
-    expect(previousPowerOfTwo(MIN_SCALE)).toBe(MIN_SCALE);
+    expect(previousPowerOfTwo(options.min, options)).toBe(options.min);
   });
 
   it("Should return max zoom if input is greater than max zoom", () => {
-    expect(previousPowerOfTwo(MAX_SCALE + 1)).toBe(MAX_SCALE);
+    expect(previousPowerOfTwo(options.max + 1, options)).toBe(options.max);
   });
 
   it("Should return min zoom if input is less than min zoom", () => {
-    expect(previousPowerOfTwo(MIN_SCALE - 1)).toBe(MIN_SCALE);
+    expect(previousPowerOfTwo(options.min - 1, options)).toBe(options.min);
   });
 });

--- a/src/math.ts
+++ b/src/math.ts
@@ -8,28 +8,36 @@ export function roundTo(x: number, to: number = 0) {
   return Math.round(x * p) / p;
 }
 
-export const MAX_SCALE = 2 ** 8;
-export const MIN_SCALE = 2 ** -6;
-
-export function nextPowerOfTwo(num: number): number {
-  const nearest = nearestPowerOfTwo(num);
-  return Math.min(MAX_SCALE, nearest > num ? nearest : nearest * 2);
+interface PowerOfTwoOptions {
+  min: number;
+  max: number;
 }
 
-export function previousPowerOfTwo(num: number): number {
-  const nearest = nearestPowerOfTwo(num);
-  return Math.max(MIN_SCALE, nearest < num ? nearest : nearest / 2);
+export function nextPowerOfTwo(
+  num: number,
+  options: PowerOfTwoOptions,
+): number {
+  const nearest = nearestPowerOfTwo(num, options);
+  return Math.min(options.max, nearest > num ? nearest : nearest * 2);
 }
 
-function nearestPowerOfTwo(num: number): number {
-  if (num < MIN_SCALE) {
-    return MIN_SCALE;
-  } else if (num > MAX_SCALE) {
-    return MAX_SCALE;
+export function previousPowerOfTwo(
+  num: number,
+  options: PowerOfTwoOptions,
+): number {
+  const nearest = nearestPowerOfTwo(num, options);
+  return Math.max(options.min, nearest < num ? nearest : nearest / 2);
+}
+
+function nearestPowerOfTwo(num: number, options: PowerOfTwoOptions): number {
+  if (num < options.min) {
+    return options.min;
+  } else if (num > options.max) {
+    return options.max;
   }
 
   if (num < 1) {
-    return 1 / nearestPowerOfTwo(1 / num);
+    return 1 / nearestPowerOfTwo(1 / num, options);
   }
 
   const power = Math.round(Math.log(num) / Math.log(2));


### PR DESCRIPTION
This PR adds support for keyboard pan/zoom actions. The keybindings here reflect Figma's behavior in the browser. The pan and zoom actions ~all occur when drag mode is enabled (spacebar is held down)~ and are supressed if the control key is pressed.

I did my best to replicate Figma's keyboard scaling behavior, which as far as I can tell changes the scale to the next (zoom in) or previous (zoom out) power of 2 including negative powers. Figma does not center keyboard scaling to the cursor, instead just keeps the position the same and scales.

Similarly, I tried to replicate Figma's keyboard panning behavior. Again, as far as I can tell, Figma will pan ~65px in regardless of scale. I based the panning on the pan speed setting in this case, but this could be hardcoded instead.

I've also added `MAX_SCALE` and `MIN_SCALE` constants to clamp scaling/zooming, again I tried to replicate what the max and min seems to be in Figma on the browser.