### PR TITLE
Allow browser zoom/scroll keybindings, add 100% zoom and zoom to fit bindings

### DIFF
--- a/src/FigspecFileViewer.ts
+++ b/src/FigspecFileViewer.ts
@@ -134,8 +134,12 @@ export class FigspecFileViewer extends HTMLElement {
         });
       });
     },
-    frameCanvas: ([, images, canvases], $selected, $loadedState) => {
-      const frameCanvas = new FrameCanvas(this.#preferences, $selected);
+    frameCanvas: ([, images, canvases], $selected, $loadedState, $snackbar) => {
+      const frameCanvas = new FrameCanvas(
+        this.#preferences,
+        $selected,
+        $snackbar,
+      );
 
       effect(() => {
         $selected.set(null);

--- a/src/FigspecFrameViewer.ts
+++ b/src/FigspecFrameViewer.ts
@@ -97,8 +97,12 @@ export class FigspecFrameViewer extends HTMLElement {
         }),
       ]);
     },
-    frameCanvas: ([, node, image], $selected, $loadedState) => {
-      const frameCanvas = new FrameCanvas(this.#preferences, $selected);
+    frameCanvas: ([, node, image], $selected, $loadedState, $snackbar) => {
+      const frameCanvas = new FrameCanvas(
+        this.#preferences,
+        $selected,
+        $snackbar,
+      );
 
       frameCanvas.render([node], new Map([[node.id, image]]));
 

--- a/src/FrameCanvas/FrameCanvas.ts
+++ b/src/FrameCanvas/FrameCanvas.ts
@@ -59,7 +59,12 @@ export class FrameCanvas {
         flex-direction: column-reverse;
 
         background-color: var(--canvas-bg);
+        border-radius: var(--border-radius);
         touch-action: none;
+      }
+      .fc-viewport:focus-visible {
+        outline: 2px solid SelectedItem;
+        outline-offset: -3px;
       }
 
       .fc-canvas {
@@ -168,6 +173,7 @@ export class FrameCanvas {
       "div",
       [
         className("fc-viewport"),
+        attr("tabindex", "0"),
         // Some UA defaults to passive (breaking but they did it anyway).
         // This component prevents every native wheel behavior on it.
         on("wheel", this.#onWheel, { passive: false }),
@@ -800,7 +806,9 @@ export class FrameCanvas {
       !["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "=", "-"].includes(
         ev.key,
       ) ||
-      ev.ctrlKey
+      !this.#focusIsInShadowRoot() ||
+      ev.ctrlKey ||
+      ev.metaKey
     ) {
       return;
     }
@@ -850,6 +858,16 @@ export class FrameCanvas {
     } else {
       return this.#container.contains(activeElement);
     }
+  }
+
+  #focusIsInShadowRoot(): boolean {
+    const shadowRoot = this.#container.getRootNode();
+
+    if (!(shadowRoot instanceof ShadowRoot)) {
+      return false;
+    }
+
+    return !!shadowRoot.activeElement;
   }
 
   #onKeyDown = (ev: KeyboardEvent) => {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -34,6 +34,7 @@ interface UIProps<T> {
     data: T,
     selected: Signal<figma.Node | null>,
     loadedState: Signal<LoadedState>,
+    snackbar: Signal<SnackbarContent>,
   ) => ElementChild;
   menuSlot?: (data: T) => ElementChild;
 
@@ -102,7 +103,12 @@ export function ui<T>({
     const $loadedState = new Signal<LoadedState>(canvas);
     const $selected = new Signal<figma.Node | null>(null);
 
-    const frameCanvas = createFrameCanvas(s.data, $selected, $loadedState);
+    const frameCanvas = createFrameCanvas(
+      s.data,
+      $selected,
+      $loadedState,
+      $snackbar,
+    );
 
     const perState = compute(() => {
       const loadedState = $loadedState.get();


### PR DESCRIPTION
This adds conditions to the keyboard zoom/pan handler to allow default browser zoom controls to continue to function and adds new bindings to replicate the zoom to 100% and zoom to fit behavior on Figma.